### PR TITLE
[runtime] Export Base's Not_found_s in runtime header.

### DIFF
--- a/runtime/ppx_python_runtime.ml
+++ b/runtime/ppx_python_runtime.ml
@@ -48,3 +48,5 @@ module Dict_str_keys = struct
     t
   ;;
 end
+
+exception Not_found_s = Base.Not_found_s

--- a/runtime/ppx_python_runtime.mli
+++ b/runtime/ppx_python_runtime.mli
@@ -22,3 +22,5 @@ module Dict_str_keys : sig
   val set : t -> string -> pyobject -> unit
   val find : t -> string -> pyobject
 end
+
+exception Not_found_s of Base.Sexp.t


### PR DESCRIPTION
The conversion routine requires for generated code that
`Base.Sexp.Not_found_s` is in scope.

Usually, this is achieved in modules using `[@@deriving python]` by
doing `open! Base`.

However, this method is a bit intrusive for existing codebases, where
`open! Base` may create many other problems, instead, we export the
exception in the runtime header.

Note that this is just one possible solution.

Signed-off-by: Emilio Jesus Gallego Arias <e+git@x80.org>